### PR TITLE
Fix args behaviour

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "eslint.experimental.useFlatConfig": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "[typescript]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@augu/clippy-action",
     "description": "🐻‍❄️📦 GitHub action to run Clippy, an up-to-date and modern version of actions-rs/clippy",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "private": true,
     "type": "module",
     "main": "build/main.js",

--- a/src/clippy.ts
+++ b/src/clippy.ts
@@ -60,8 +60,8 @@ export const getClippyOutput = async (
         args.push('--all-features');
     }
 
-    args.push('--');
     args.push(...inputs.args);
+    args.push('--');
     args.push(...inputs.forbid.map((forbid) => `-F${forbid}`));
     args.push(...inputs.deny.map((deny) => `-D${deny}`));
     args.push(...inputs.warn.map((allowed) => `-W${allowed}`));


### PR DESCRIPTION
The `args` fields should be added after `--` otherwise the action will fail.

See issue:
https://github.com/auguwu/clippy-action/issues/495